### PR TITLE
Customization v0.7.3

### DIFF
--- a/src/int/cmp.rs
+++ b/src/int/cmp.rs
@@ -8,31 +8,31 @@ use core::cmp::Ordering;
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
+    pub const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
         Uint::conditional_swap(&mut a.0, &mut b.0, c);
     }
 
     /// Returns the truthy value if `self`!=0 or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(&self) -> Choice {
+    pub const fn is_nonzero(&self) -> Choice {
         Uint::is_nonzero(&self.0)
     }
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn eq(lhs: &Self, rhs: &Self) -> Choice {
         Uint::eq(&lhs.0, &rhs.0)
     }
 
     /// Returns the truthy value if `self < rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn lt(lhs: &Self, rhs: &Self) -> Choice {
         Uint::lt(&lhs.invert_msb().0, &rhs.invert_msb().0)
     }
 
     /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn gt(lhs: &Self, rhs: &Self) -> Choice {
         Uint::gt(&lhs.invert_msb().0, &rhs.invert_msb().0)
     }
 
@@ -42,7 +42,7 @@ impl<const LIMBS: usize> Int<LIMBS> {
     ///   0 is Equal
     ///   1 is Greater
     #[inline]
-    pub(crate) const fn cmp(lhs: &Self, rhs: &Self) -> Ordering {
+    pub const fn cmp(lhs: &Self, rhs: &Self) -> Ordering {
         Uint::cmp(&lhs.invert_msb().0, &rhs.invert_msb().0)
     }
 

--- a/src/int/ct.rs
+++ b/src/int/ct.rs
@@ -6,7 +6,7 @@ use ctutils::{CtAssignSlice, CtEqSlice};
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: Choice) -> Self {
+    pub const fn select(a: &Self, b: &Self, c: Choice) -> Self {
         Self(Uint::select(&a.0, &b.0, c))
     }
 }

--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -1,6 +1,6 @@
 //! Const-friendly decoding/encoding operations for [`Int`].
 
-use crate::{Int, Uint};
+use crate::{Encoding, Int, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a new [`Int`] from the provided big endian hex string.
@@ -12,5 +12,54 @@ impl<const LIMBS: usize> Int<LIMBS> {
     #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
+    }
+
+    /// Create a new [`Int`] from the provided big endian bytes.
+    ///
+    /// See [`Uint::from_be_slice`] for more details.
+    pub const fn from_be_slice(bytes: &[u8]) -> Self {
+        Self(Uint::from_be_slice(bytes))
+    }
+
+    /// Create a new [`Int`] from the provided little endian bytes.
+    ///
+    /// See [`Uint::from_le_slice`] for more details.
+    pub const fn from_le_slice(bytes: &[u8]) -> Self {
+        Self(Uint::from_le_slice(bytes))
+    }
+
+    /// Create a new [`Int`] from the provided little endian hex string.
+    ///
+    /// See [`Uint::from_le_hex`] for more details.
+    ///
+    /// # Panics
+    /// - if the hex is malformed or not zero-padded accordingly for the size.
+    #[must_use]
+    pub const fn from_le_hex(hex: &str) -> Self {
+        Self(Uint::from_le_hex(hex))
+    }
+}
+
+impl<const LIMBS: usize> Encoding for Int<LIMBS> {
+    type Repr = <Uint<LIMBS> as Encoding>::Repr;
+
+    #[inline]
+    fn from_be_bytes(bytes: Self::Repr) -> Self {
+        Self(Uint::<LIMBS>::from_be_bytes(bytes))
+    }
+
+    #[inline]
+    fn from_le_bytes(bytes: Self::Repr) -> Self {
+        Self(Uint::<LIMBS>::from_le_bytes(bytes))
+    }
+
+    #[inline]
+    fn to_be_bytes(&self) -> Self::Repr {
+        self.0.to_be_bytes()
+    }
+
+    #[inline]
+    fn to_le_bytes(&self) -> Self::Repr {
+        self.0.to_le_bytes()
     }
 }

--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -13,6 +13,31 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
     }
+
+    /// Create a new [`Int`] from the provided big endian bytes.
+    ///
+    /// See [`Uint::from_be_slice`] for more details.
+    pub const fn from_be_slice(bytes: &[u8]) -> Self {
+        Self(Uint::from_be_slice(bytes))
+    }
+
+    /// Create a new [`Int`] from the provided little endian bytes.
+    ///
+    /// See [`Uint::from_le_slice`] for more details.
+    pub const fn from_le_slice(bytes: &[u8]) -> Self {
+        Self(Uint::from_le_slice(bytes))
+    }
+
+    /// Create a new [`Int`] from the provided little endian hex string.
+    ///
+    /// See [`Uint::from_le_hex`] for more details.
+    ///
+    /// # Panics
+    /// - if the hex is malformed or not zero-padded accordingly for the size.
+    #[must_use]
+    pub const fn from_le_hex(hex: &str) -> Self {
+        Self(Uint::from_le_hex(hex))
+    }
 }
 
 impl<const LIMBS: usize> Encoding for Int<LIMBS> {

--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -13,31 +13,6 @@ impl<const LIMBS: usize> Int<LIMBS> {
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
     }
-
-    /// Create a new [`Int`] from the provided big endian bytes.
-    ///
-    /// See [`Uint::from_be_slice`] for more details.
-    pub const fn from_be_slice(bytes: &[u8]) -> Self {
-        Self(Uint::from_be_slice(bytes))
-    }
-
-    /// Create a new [`Int`] from the provided little endian bytes.
-    ///
-    /// See [`Uint::from_le_slice`] for more details.
-    pub const fn from_le_slice(bytes: &[u8]) -> Self {
-        Self(Uint::from_le_slice(bytes))
-    }
-
-    /// Create a new [`Int`] from the provided little endian hex string.
-    ///
-    /// See [`Uint::from_le_hex`] for more details.
-    ///
-    /// # Panics
-    /// - if the hex is malformed or not zero-padded accordingly for the size.
-    #[must_use]
-    pub const fn from_le_hex(hex: &str) -> Self {
-        Self(Uint::from_le_hex(hex))
-    }
 }
 
 impl<const LIMBS: usize> Encoding for Int<LIMBS> {

--- a/src/int/encoding.rs
+++ b/src/int/encoding.rs
@@ -1,6 +1,6 @@
 //! Const-friendly decoding/encoding operations for [`Int`].
 
-use crate::{Encoding, Int, Uint};
+use crate::{Int, Uint};
 
 impl<const LIMBS: usize> Int<LIMBS> {
     /// Create a new [`Int`] from the provided big endian hex string.
@@ -12,54 +12,5 @@ impl<const LIMBS: usize> Int<LIMBS> {
     #[must_use]
     pub const fn from_be_hex(hex: &str) -> Self {
         Self(Uint::from_be_hex(hex))
-    }
-
-    /// Create a new [`Int`] from the provided big endian bytes.
-    ///
-    /// See [`Uint::from_be_slice`] for more details.
-    pub const fn from_be_slice(bytes: &[u8]) -> Self {
-        Self(Uint::from_be_slice(bytes))
-    }
-
-    /// Create a new [`Int`] from the provided little endian bytes.
-    ///
-    /// See [`Uint::from_le_slice`] for more details.
-    pub const fn from_le_slice(bytes: &[u8]) -> Self {
-        Self(Uint::from_le_slice(bytes))
-    }
-
-    /// Create a new [`Int`] from the provided little endian hex string.
-    ///
-    /// See [`Uint::from_le_hex`] for more details.
-    ///
-    /// # Panics
-    /// - if the hex is malformed or not zero-padded accordingly for the size.
-    #[must_use]
-    pub const fn from_le_hex(hex: &str) -> Self {
-        Self(Uint::from_le_hex(hex))
-    }
-}
-
-impl<const LIMBS: usize> Encoding for Int<LIMBS> {
-    type Repr = <Uint<LIMBS> as Encoding>::Repr;
-
-    #[inline]
-    fn from_be_bytes(bytes: Self::Repr) -> Self {
-        Self(Uint::<LIMBS>::from_be_bytes(bytes))
-    }
-
-    #[inline]
-    fn from_le_bytes(bytes: Self::Repr) -> Self {
-        Self(Uint::<LIMBS>::from_le_bytes(bytes))
-    }
-
-    #[inline]
-    fn to_be_bytes(&self) -> Self::Repr {
-        self.0.to_be_bytes()
-    }
-
-    #[inline]
-    fn to_le_bytes(&self) -> Self::Repr {
-        self.0.to_le_bytes()
     }
 }

--- a/src/limb/cmp.rs
+++ b/src/limb/cmp.rs
@@ -28,7 +28,7 @@ impl Limb {
 
     /// Returns the truthy value if `self != 0` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn is_nonzero(self) -> Choice {
+    pub const fn is_nonzero(self) -> Choice {
         word::choice_from_nz(self.0)
     }
 }

--- a/src/limb/ct.rs
+++ b/src/limb/ct.rs
@@ -6,7 +6,7 @@ use ctutils::{CtAssignSlice, CtEqSlice};
 impl Limb {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: Self, b: Self, c: Choice) -> Self {
+    pub const fn select(a: Self, b: Self, c: Choice) -> Self {
         Self(word::select(a.0, b.0, c))
     }
 

--- a/src/uint/cmp.rs
+++ b/src/uint/cmp.rs
@@ -31,7 +31,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self == rhs` or the falsy value otherwise.
     #[inline]
-    pub(crate) const fn eq(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn eq(lhs: &Self, rhs: &Self) -> Choice {
         let mut acc = 0;
         let mut i = 0;
 
@@ -46,25 +46,25 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Returns the truthy value if `self < rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lt(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn lt(lhs: &Self, rhs: &Self) -> Choice {
         UintRef::lt(lhs.as_uint_ref(), rhs.as_uint_ref())
     }
 
     /// Returns the truthy value if `self <= rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn lte(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn lte(lhs: &Self, rhs: &Self) -> Choice {
         Self::gt(lhs, rhs).not()
     }
 
     /// Returns the truthy value if `self > rhs` and the falsy value otherwise.
     #[inline]
-    pub(crate) const fn gt(lhs: &Self, rhs: &Self) -> Choice {
+    pub const fn gt(lhs: &Self, rhs: &Self) -> Choice {
         UintRef::lt(rhs.as_uint_ref(), lhs.as_uint_ref())
     }
 
     /// Returns the Ordering between `self` and `rhs`.
     #[inline]
-    pub(crate) const fn cmp(lhs: &Self, rhs: &Self) -> Ordering {
+    pub const fn cmp(lhs: &Self, rhs: &Self) -> Ordering {
         UintRef::cmp(lhs.as_uint_ref(), rhs.as_uint_ref())
     }
 

--- a/src/uint/ct.rs
+++ b/src/uint/ct.rs
@@ -6,7 +6,7 @@ use ctutils::{CtAssignSlice, CtEqSlice};
 impl<const LIMBS: usize> Uint<LIMBS> {
     /// Return `b` if `c` is truthy, otherwise return `a`.
     #[inline]
-    pub(crate) const fn select(a: &Self, b: &Self, c: Choice) -> Self {
+    pub const fn select(a: &Self, b: &Self, c: Choice) -> Self {
         let mut limbs = [Limb::ZERO; LIMBS];
 
         let mut i = 0;
@@ -20,7 +20,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Swap `a` and `b` if `c` is truthy, otherwise, do nothing.
     #[inline]
-    pub(crate) const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
+    pub const fn conditional_swap(a: &mut Self, b: &mut Self, c: Choice) {
         let mut i = 0;
         let a = a.as_mut_limbs();
         let b = b.as_mut_limbs();
@@ -32,7 +32,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
 
     /// Swap `a` and `b`
     #[inline]
-    pub(crate) const fn swap(a: &mut Self, b: &mut Self) {
+    pub const fn swap(a: &mut Self, b: &mut Self) {
         Self::conditional_swap(a, b, Choice::TRUE);
     }
 }

--- a/src/uint/div.rs
+++ b/src/uint/div.rs
@@ -244,6 +244,54 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     ) -> CtOption<Uint<RHS_LIMBS>> {
         NonZero::new(*rhs).map(|rhs| self.rem(&rhs))
     }
+
+    /// Computes `self << shift` where `0 <= shift < Limb::BITS`,
+    /// returning the result and the carry.
+    ///
+    /// Note: assumes that `self` only has `limbs_num` lowest non-zero limbs.
+    pub const fn shl_limb_vartime(&self, shift: u32, limbs_num: usize) -> (Self, Limb) {
+        if shift == 0 {
+            return (*self, Limb::ZERO);
+        }
+
+        let mut limbs = [Limb::ZERO; LIMBS];
+
+        let lshift = shift;
+        let rshift = Limb::BITS - shift;
+
+        let carry = self.limbs[limbs_num - 1].0 >> rshift;
+        let mut i = limbs_num - 1;
+        while i > 0 {
+            limbs[i] = Limb((self.limbs[i].0 << lshift) | (self.limbs[i - 1].0 >> rshift));
+            i -= 1;
+        }
+        limbs[0] = Limb(self.limbs[0].0 << lshift);
+
+        (Uint::<LIMBS>::new(limbs), Limb(carry))
+    }
+
+    /// Computes `self >> shift` where `0 <= shift < Limb::BITS`.
+    ///
+    /// Note: assumes that `self` only has `limbs_num` lowest non-zero limbs.
+    pub const fn shr_limb_vartime(&self, shift: u32, limbs_num: usize) -> Self {
+        if shift == 0 {
+            return *self;
+        }
+
+        let mut limbs = [Limb::ZERO; LIMBS];
+
+        let lshift = Limb::BITS - shift;
+        let rshift = shift;
+
+        let mut i = 0;
+        while i < limbs_num - 1 {
+            limbs[i] = Limb((self.limbs[i].0 >> rshift) | (self.limbs[i + 1].0 << lshift));
+            i += 1;
+        }
+        limbs[limbs_num - 1] = Limb(self.limbs[limbs_num - 1].0 >> rshift);
+
+        Uint::<LIMBS>::new(limbs)
+    }
 }
 
 impl<const LIMBS: usize, const RHS_LIMBS: usize> CheckedDiv<Uint<RHS_LIMBS>> for Uint<LIMBS> {

--- a/src/uint/shl.rs
+++ b/src/uint/shl.rs
@@ -171,7 +171,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self << 1` in constant-time.
     #[inline(always)]
     #[must_use]
-    pub(crate) const fn shl1(&self) -> Self {
+    pub const fn shl1(&self) -> Self {
         let mut res = *self;
         res.as_mut_uint_ref().shl1_assign();
         res
@@ -181,10 +181,19 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// and a high carry limb.
     #[inline(always)]
     #[must_use]
-    pub(crate) const fn shl1_with_carry(&self, carry: Limb) -> (Self, Limb) {
+    pub const fn shl1_with_carry(&self, carry: Limb) -> (Self, Limb) {
         let mut res = *self;
         let carry = res.as_mut_uint_ref().shl1_assign_with_carry(carry);
         (res, carry)
+    }
+
+    /// Computes `self << 1` in constant-time, returning the shifted result and
+    /// the high carry limb (no carry-in). Equivalent to
+    /// [`Self::shl1_with_carry`] called with [`Limb::ZERO`].
+    #[inline(always)]
+    #[must_use]
+    pub const fn overflowing_shl1(&self) -> (Self, Limb) {
+        self.shl1_with_carry(Limb::ZERO)
     }
 
     /// Computes `self << shift` where `0 <= shift < Limb::BITS`,

--- a/src/uint/shr.rs
+++ b/src/uint/shr.rs
@@ -181,7 +181,7 @@ impl<const LIMBS: usize> Uint<LIMBS> {
     /// Computes `self >> 1` in constant-time.
     #[inline(always)]
     #[must_use]
-    pub(crate) const fn shr1(&self) -> Self {
+    pub const fn shr1(&self) -> Self {
         let mut res = *self;
         res.as_mut_uint_ref().shr1_assign();
         res


### PR DESCRIPTION
Rebases the cryptography-private workspace's customizations from the older fork base (commit 8aabcee5, self-versioned 0.7.0-rc.9) onto upstream stable v0.7.3.

## Audit summary

Of the original 5 fork-only commits on top of 7ba1398 v0.7.0-rc.9:

- 0ef5fde "Int encoding" — partially kept. Re-applied Int::from_{be,le}_slice / from_le_hex methods + impl Encoding for Int<LIMBS>. Dropped extended I-type aliases (I192..I32768); workspace only uses I64..I4096 which upstream v0.7.3 provides.
- 5f03eff "Expose functions" — kept as visibility-only flips. Upstream v0.7.3 already merged Choice and ConstChoice into the same type (deprecated alias), so no separate API was needed. pub(crate) → pub on Uint::{select, conditional_swap, swap, eq, lt, lte, gt, cmp, shl1, shl1_with_carry, shr1}, Int::{select, conditional_swap, is_nonzero, eq, lt, gt, cmp}, Limb::{select, is_nonzero}.
- fcd2f99 Expose UintRef + 8aabcee Make UintRef non public again — dropped (cancel out).
- 901e797 "shr_limb_vartime() / shl_limb_vartime()" — kept.

Added Uint::overflowing_shl1 as a thin wrapper over upstream's shl1_with_carry(Limb::ZERO) so the workspace's existing call shape keeps working.

## Verification

- cargo build --release on the fork: clean.
- dwallet-labs/cryptography-private workspace builds, class-groups tests pass 235/235.